### PR TITLE
feat(auth): verification, login code, and session cookie (#11, #12, #13)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,6 +8,42 @@
 - **Identity**:
     - Step 1: Gov ID verification against external provider; upsert local user & roles.
     - Step 2: Contact → 6-digit code (24h) → session cookie.
+
+## Auth Flow
+
+The authentication system follows a 3-step process:
+
+### 1. Government ID Verification (`POST /api/auth/verify-id`)
+- Accepts Gov ID in format `ID-UK-xxx` (e.g., `ID-UK-001`)
+- Calls external USER_PROVIDER service with Basic auth
+- Falls back to demo data when provider unavailable
+- Upserts user record and syncs system roles (RES/SOL/CWS/JDG)
+- Returns normalized user object with roles
+
+### 2. Verification Code Request (`POST /api/auth/request-code`)  
+- Accepts any contact string (demo mode)
+- Generates secure 6-digit numeric code with 24-hour TTL
+- Stores in `login_codes` table with expiry timestamp
+- Returns code directly in response (demo shortcut for testing)
+
+### 3. Code Verification (`POST /api/auth/verify-code`)
+- Validates unused, unexpired 6-digit code
+- Creates signed session cookie (`SMCCCMS_SESSION`)
+- Marks code as consumed in database
+- Returns user object with roles for frontend
+
+### Session Management
+- HTTP-only cookies with signed session IDs
+- In-memory session storage for demo (not production-ready)
+- 24-hour session lifetime
+- Sessions include user ID for authorization
+
+### Role Assignment
+Demo users are assigned roles based on Gov ID number:
+- **RES** (Resident): Default role for all users
+- **SOL** (Solicitor): Every 7th user (007, 014, 021...)  
+- **CWS** (Caseworker): Every 11th user (011, 022, 033...)
+- **JDG** (Judge): Every 17th user (017, 034, 051...)
 - **Roles**: RES, SOL, CWS, JDG. Per-case roles: CLAIMANT, DEFENDANT, JUDGE, CASEWORKER (+ optional solicitors).
 - **Case states**: DRAFT → SUBMITTED → REVIEW → DEFENCE → HEARING → DECISION → CLOSED.
 - **AI**: Backend proxies to Claude 3 Haiku for rewrite, amount suggestion, and decision support.

--- a/examples/auth-flow-curl.md
+++ b/examples/auth-flow-curl.md
@@ -1,16 +1,108 @@
 # Auth flow (cURL demo)
 
-# 1) Verify Gov ID (upserts user/roles)
-curl -sS -X POST http://localhost:18081/auth/verify-id \
--H 'Content-Type: application/json' \
--d '{"govId":"ID-UK-001"}'
+## 1) Verify Gov ID (upserts user/roles)
+```bash
+curl -X POST http://localhost:8080/api/auth/verify-id \
+  -H 'Content-Type: application/json' \
+  -d '{"govId":"ID-UK-001"}'
+```
 
-# 2) Request login code (returns code in response for demo)
-curl -sS -X POST http://localhost:18081/auth/request-code \
--H 'Content-Type: application/json' \
--d '{"contact":"anything@demo"}'
+**Expected Response:**
+```json
+{
+  "id": 1,
+  "govId": "ID-UK-001",
+  "firstName": "User1",
+  "lastName": "Demo",
+  "roles": ["RES"]
+}
+```
 
-# 3) Verify code (establishes session cookie)
-curl -i -sS -X POST http://localhost:18081/auth/verify-code \
--H 'Content-Type: application/json' \
--d '{"code":"123456"}'
+## 2) Request login code (returns code in response for demo)
+```bash
+curl -X POST http://localhost:8080/api/auth/request-code \
+  -H 'Content-Type: application/json' \
+  -d '{"contact":"test@example.com"}'
+```
+
+**Expected Response:**
+```json
+{
+  "code": "123456"
+}
+```
+
+## 3) Verify code (establishes session cookie)
+```bash
+curl -i -X POST http://localhost:8080/api/auth/verify-code \
+  -H 'Content-Type: application/json' \
+  -d '{"code":"123456"}' \
+  -c cookies.txt
+```
+
+**Expected Response:**
+```json
+{
+  "id": 1,
+  "govId": "ID-UK-001", 
+  "firstName": "User1",
+  "lastName": "Demo",
+  "roles": ["RES"]
+}
+```
+
+**Note:** Session cookie `SMCCCMS_SESSION` will be saved to `cookies.txt`
+
+## Complete Flow Example
+
+```bash
+# Step 1: Verify ID
+RESPONSE1=$(curl -s -X POST http://localhost:8080/api/auth/verify-id \
+  -H 'Content-Type: application/json' \
+  -d '{"govId":"ID-UK-001"}')
+
+echo "Step 1 - Verify ID: $RESPONSE1"
+
+# Step 2: Request code  
+RESPONSE2=$(curl -s -X POST http://localhost:8080/api/auth/request-code \
+  -H 'Content-Type: application/json' \
+  -d '{"contact":"test@example.com"}')
+
+echo "Step 2 - Request Code: $RESPONSE2"
+
+# Step 3: Extract code and verify
+CODE=$(echo "$RESPONSE2" | jq -r '.code')
+RESPONSE3=$(curl -s -X POST http://localhost:8080/api/auth/verify-code \
+  -H 'Content-Type: application/json' \
+  -d "{\"code\":\"$CODE\"}" \
+  -c cookies.txt)
+
+echo "Step 3 - Verify Code: $RESPONSE3"
+echo "Session cookie saved to cookies.txt"
+```
+
+## Different User Roles
+
+Test with different Gov IDs to see different roles:
+
+```bash
+# Regular user (RES)
+curl -X POST http://localhost:8080/api/auth/verify-id \
+  -H 'Content-Type: application/json' \
+  -d '{"govId":"ID-UK-001"}'
+
+# Solicitor (SOL) - every 7th user
+curl -X POST http://localhost:8080/api/auth/verify-id \
+  -H 'Content-Type: application/json' \
+  -d '{"govId":"ID-UK-007"}'
+
+# Caseworker (CWS) - every 11th user  
+curl -X POST http://localhost:8080/api/auth/verify-id \
+  -H 'Content-Type: application/json' \
+  -d '{"govId":"ID-UK-011"}'
+
+# Judge (JDG) - every 17th user
+curl -X POST http://localhost:8080/api/auth/verify-id \
+  -H 'Content-Type: application/json' \
+  -d '{"govId":"ID-UK-017"}'
+```

--- a/smcccms_be/README.md
+++ b/smcccms_be/README.md
@@ -1,0 +1,64 @@
+# SMCCCMS Backend
+
+Small Claims Court Council Management System - Backend API
+
+## Quick Start
+
+1. **Start Database:**
+   ```bash
+   cd ops && docker-compose -f docker-compose.db.yml up -d
+   ```
+
+2. **Run Backend:**
+   ```bash
+   cd smcccms_be
+   ./mvnw spring-boot:run
+   ```
+
+3. **Open Swagger UI:**
+   - http://localhost:8080/api/swagger-ui/index.html
+
+## Authentication Endpoints
+
+### 1. Verify Government ID
+```bash
+curl -X POST http://localhost:8080/api/auth/verify-id \
+  -H "Content-Type: application/json" \
+  -d '{"govId": "ID-UK-001"}'
+```
+
+### 2. Request Verification Code
+```bash
+curl -X POST http://localhost:8080/api/auth/request-code \
+  -H "Content-Type: application/json" \
+  -d '{"contact": "test@example.com"}'
+```
+
+### 3. Verify Code & Create Session
+```bash
+curl -X POST http://localhost:8080/api/auth/verify-code \
+  -H "Content-Type: application/json" \
+  -d '{"code": "123456"}' \
+  -c cookies.txt
+```
+
+## Configuration
+
+Environment variables:
+- `DB_USERNAME` (default: smcccms_admin)  
+- `DB_PASSWORD` (default: SMCCCMSdemo)
+- `USER_PROVIDER_BASE_URL` (default: http://localhost:8081)
+- `USER_PROVIDER_USERNAME` (default: demo)
+- `USER_PROVIDER_PASSWORD` (default: demo)
+- `SESSION_SECRET` (default: demo key - change in production!)
+
+## Tech Stack
+
+- Spring Boot 3.2.12
+- Java 21
+- PostgreSQL 16 (Docker)
+- JDBC (no JPA)
+- Flyway migrations
+- SpringDoc OpenAPI
+
+See [examples/auth-flow-curl.md](../examples/auth-flow-curl.md) for complete authentication flow examples.

--- a/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/controller/AuthController.java
+++ b/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/controller/AuthController.java
@@ -1,0 +1,169 @@
+package uk.gov.demo.smcccms.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.demo.smcccms.auth.dto.*;
+import uk.gov.demo.smcccms.auth.repository.UserRepository;
+import uk.gov.demo.smcccms.auth.service.LoginCodeService;
+import uk.gov.demo.smcccms.auth.service.SessionService;
+import uk.gov.demo.smcccms.auth.service.UserProviderClient;
+
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/auth")
+@Tag(name = "Authentication", description = "Authentication endpoints for government ID verification and login")
+public class AuthController {
+    
+    private static final Logger logger = LoggerFactory.getLogger(AuthController.class);
+    
+    private final UserProviderClient userProviderClient;
+    private final UserRepository userRepository;
+    private final LoginCodeService loginCodeService;
+    private final SessionService sessionService;
+    
+    public AuthController(UserProviderClient userProviderClient,
+                          UserRepository userRepository,
+                          LoginCodeService loginCodeService,
+                          SessionService sessionService) {
+        this.userProviderClient = userProviderClient;
+        this.userRepository = userRepository;
+        this.loginCodeService = loginCodeService;
+        this.sessionService = sessionService;
+    }
+    
+    @PostMapping("/verify-id")
+    @Operation(summary = "Verify government ID", 
+               description = "Verifies a government ID with external provider and creates/updates local user")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "ID verified successfully",
+                    content = @Content(schema = @Schema(implementation = UserResponse.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid ID format"),
+        @ApiResponse(responseCode = "502", description = "User provider unavailable")
+    })
+    public ResponseEntity<?> verifyId(@Valid @RequestBody VerifyIdRequest request) {
+        try {
+            logger.info("Verifying government ID: {}", request.getGovId());
+            
+            // Call external user provider
+            UserProviderClient.ProviderUserInfo providerInfo = userProviderClient.verifyId(request.getGovId());
+            
+            // Upsert user in local database
+            Long userId = userRepository.upsertUser(
+                providerInfo.providerId, 
+                request.getGovId(), 
+                providerInfo.firstName, 
+                providerInfo.lastName
+            );
+            
+            // Sync roles
+            userRepository.syncUserRoles(userId, providerInfo.roles);
+            
+            // Return normalized user object
+            Optional<UserResponse> user = userRepository.findById(userId);
+            if (user.isPresent()) {
+                logger.info("User verified and upserted: govId={}, userId={}", request.getGovId(), userId);
+                return ResponseEntity.ok(user.get());
+            } else {
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "Failed to retrieve user after upsert"));
+            }
+            
+        } catch (Exception e) {
+            logger.error("Failed to verify government ID: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+                .body(Map.of("error", "User verification failed", "details", e.getMessage()));
+        }
+    }
+    
+    @PostMapping("/request-code")
+    @Operation(summary = "Request verification code", 
+               description = "Generates a 6-digit verification code with 24-hour TTL (demo returns code directly)")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Code generated successfully",
+                    content = @Content(schema = @Schema(implementation = CodeResponse.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid contact information")
+    })
+    public ResponseEntity<?> requestCode(@Valid @RequestBody ContactRequest request) {
+        try {
+            logger.info("Requesting verification code for contact: {}", request.getContact());
+            
+            // For demo purposes, we'll use the first user (ID-UK-001) as the default user
+            // In a real implementation, we'd associate the contact with a specific user
+            Optional<UserResponse> user = userRepository.findByGovId("ID-UK-001");
+            if (user.isEmpty()) {
+                return ResponseEntity.badRequest()
+                    .body(Map.of("error", "No user found for code generation"));
+            }
+            
+            String code = loginCodeService.generateCode(user.get().getId());
+            
+            logger.info("Generated verification code for user ID: {}", user.get().getId());
+            
+            // In demo mode, return the code directly (normally would be sent via SMS/email)
+            return ResponseEntity.ok(new CodeResponse(code));
+            
+        } catch (Exception e) {
+            logger.error("Failed to generate verification code: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Map.of("error", "Code generation failed", "details", e.getMessage()));
+        }
+    }
+    
+    @PostMapping("/verify-code")
+    @Operation(summary = "Verify login code", 
+               description = "Validates 6-digit code and creates authenticated session")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Code verified, session created",
+                    content = @Content(schema = @Schema(implementation = UserResponse.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid code format"),
+        @ApiResponse(responseCode = "401", description = "Code invalid, expired, or already used")
+    })
+    public ResponseEntity<?> verifyCode(@Valid @RequestBody CodeRequest request, 
+                                        HttpServletResponse response) {
+        try {
+            logger.info("Verifying login code: {}", request.getCode());
+            
+            Optional<Long> userId = loginCodeService.validateAndConsumeCode(request.getCode());
+            
+            if (userId.isEmpty()) {
+                logger.warn("Invalid or expired code: {}", request.getCode());
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("error", "Invalid or expired verification code"));
+            }
+            
+            // Create session
+            sessionService.createSession(userId.get(), response);
+            
+            // Return user object
+            Optional<UserResponse> user = userRepository.findById(userId.get());
+            if (user.isPresent()) {
+                logger.info("Code verified and session created for user ID: {}", userId.get());
+                return ResponseEntity.ok(user.get());
+            } else {
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "Failed to retrieve user after code verification"));
+            }
+            
+        } catch (Exception e) {
+            logger.error("Failed to verify code: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Map.of("error", "Code verification failed", "details", e.getMessage()));
+        }
+    }
+}

--- a/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/dto/CodeRequest.java
+++ b/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/dto/CodeRequest.java
@@ -1,0 +1,25 @@
+package uk.gov.demo.smcccms.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public class CodeRequest {
+    
+    @NotBlank(message = "Verification code is required")
+    @Pattern(regexp = "^\\d{6}$", message = "Code must be 6 digits")
+    private String code;
+    
+    public CodeRequest() {}
+    
+    public CodeRequest(String code) {
+        this.code = code;
+    }
+    
+    public String getCode() {
+        return code;
+    }
+    
+    public void setCode(String code) {
+        this.code = code;
+    }
+}

--- a/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/dto/CodeResponse.java
+++ b/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/dto/CodeResponse.java
@@ -1,0 +1,20 @@
+package uk.gov.demo.smcccms.auth.dto;
+
+public class CodeResponse {
+    
+    private String code;
+    
+    public CodeResponse() {}
+    
+    public CodeResponse(String code) {
+        this.code = code;
+    }
+    
+    public String getCode() {
+        return code;
+    }
+    
+    public void setCode(String code) {
+        this.code = code;
+    }
+}

--- a/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/dto/ContactRequest.java
+++ b/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/dto/ContactRequest.java
@@ -1,0 +1,23 @@
+package uk.gov.demo.smcccms.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class ContactRequest {
+    
+    @NotBlank(message = "Contact information is required")
+    private String contact;
+    
+    public ContactRequest() {}
+    
+    public ContactRequest(String contact) {
+        this.contact = contact;
+    }
+    
+    public String getContact() {
+        return contact;
+    }
+    
+    public void setContact(String contact) {
+        this.contact = contact;
+    }
+}

--- a/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/dto/UserResponse.java
+++ b/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/dto/UserResponse.java
@@ -1,0 +1,62 @@
+package uk.gov.demo.smcccms.auth.dto;
+
+import java.util.List;
+
+public class UserResponse {
+    
+    private Long id;
+    private String govId;
+    private String firstName;
+    private String lastName;
+    private List<String> roles;
+    
+    public UserResponse() {}
+    
+    public UserResponse(Long id, String govId, String firstName, String lastName, List<String> roles) {
+        this.id = id;
+        this.govId = govId;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.roles = roles;
+    }
+    
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public String getGovId() {
+        return govId;
+    }
+    
+    public void setGovId(String govId) {
+        this.govId = govId;
+    }
+    
+    public String getFirstName() {
+        return firstName;
+    }
+    
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+    
+    public String getLastName() {
+        return lastName;
+    }
+    
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+    
+    public List<String> getRoles() {
+        return roles;
+    }
+    
+    public void setRoles(List<String> roles) {
+        this.roles = roles;
+    }
+}

--- a/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/dto/VerifyIdRequest.java
+++ b/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/dto/VerifyIdRequest.java
@@ -1,0 +1,25 @@
+package uk.gov.demo.smcccms.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public class VerifyIdRequest {
+    
+    @NotBlank(message = "Government ID is required")
+    @Pattern(regexp = "^ID-UK-\\d{3}$", message = "Invalid government ID format")
+    private String govId;
+    
+    public VerifyIdRequest() {}
+    
+    public VerifyIdRequest(String govId) {
+        this.govId = govId;
+    }
+    
+    public String getGovId() {
+        return govId;
+    }
+    
+    public void setGovId(String govId) {
+        this.govId = govId;
+    }
+}

--- a/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/repository/LoginCodeRepository.java
+++ b/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/repository/LoginCodeRepository.java
@@ -1,0 +1,62 @@
+package uk.gov.demo.smcccms.auth.repository;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+public class LoginCodeRepository {
+    
+    private final JdbcTemplate jdbcTemplate;
+    
+    public LoginCodeRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+    
+    @Transactional
+    public Long createLoginCode(Long userId, String code, LocalDateTime expiresAt) {
+        String sql = "INSERT INTO login_codes (user_id, code, expires_at) VALUES (?, ?, ?)";
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        
+        jdbcTemplate.update(connection -> {
+            PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+            ps.setLong(1, userId);
+            ps.setString(2, code);
+            ps.setTimestamp(3, Timestamp.valueOf(expiresAt));
+            return ps;
+        }, keyHolder);
+        
+        return ((Number) keyHolder.getKeys().get("id")).longValue();
+    }
+    
+    public Optional<Long> findUserIdByValidCode(String code) {
+        String sql = "SELECT user_id FROM login_codes WHERE code = ? AND expires_at > ? AND consumed_at IS NULL";
+        
+        var results = jdbcTemplate.query(sql, 
+            (rs, rowNum) -> rs.getLong("user_id"),
+            code, Timestamp.valueOf(LocalDateTime.now())
+        );
+        
+        return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+    }
+    
+    @Transactional
+    public void consumeCode(String code) {
+        String sql = "UPDATE login_codes SET consumed_at = ? WHERE code = ? AND consumed_at IS NULL";
+        jdbcTemplate.update(sql, Timestamp.valueOf(LocalDateTime.now()), code);
+    }
+    
+    @Transactional
+    public void cleanupExpiredCodes() {
+        String sql = "DELETE FROM login_codes WHERE expires_at < ?";
+        jdbcTemplate.update(sql, Timestamp.valueOf(LocalDateTime.now()));
+    }
+}

--- a/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/repository/UserRepository.java
+++ b/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/repository/UserRepository.java
@@ -1,0 +1,104 @@
+package uk.gov.demo.smcccms.auth.repository;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.demo.smcccms.auth.dto.UserResponse;
+
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class UserRepository {
+    
+    private final JdbcTemplate jdbcTemplate;
+    
+    public UserRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+    
+    private final RowMapper<UserResponse> userRowMapper = (rs, rowNum) -> {
+        UserResponse user = new UserResponse();
+        user.setId(rs.getLong("id"));
+        user.setGovId(rs.getString("gov_id"));
+        user.setFirstName(rs.getString("first_name"));
+        user.setLastName(rs.getString("last_name"));
+        return user;
+    };
+    
+    public Optional<UserResponse> findByGovId(String govId) {
+        String sql = "SELECT id, gov_id, first_name, last_name FROM users WHERE gov_id = ?";
+        List<UserResponse> users = jdbcTemplate.query(sql, userRowMapper, govId);
+        
+        if (users.isEmpty()) {
+            return Optional.empty();
+        }
+        
+        UserResponse user = users.get(0);
+        user.setRoles(findUserRoles(user.getId()));
+        return Optional.of(user);
+    }
+    
+    public Optional<UserResponse> findById(Long id) {
+        String sql = "SELECT id, gov_id, first_name, last_name FROM users WHERE id = ?";
+        List<UserResponse> users = jdbcTemplate.query(sql, userRowMapper, id);
+        
+        if (users.isEmpty()) {
+            return Optional.empty();
+        }
+        
+        UserResponse user = users.get(0);
+        user.setRoles(findUserRoles(user.getId()));
+        return Optional.of(user);
+    }
+    
+    @Transactional
+    public Long upsertUser(String providerUserId, String govId, String firstName, String lastName) {
+        String selectSql = "SELECT id FROM users WHERE gov_id = ?";
+        List<Long> existingIds = jdbcTemplate.query(selectSql, (rs, rowNum) -> rs.getLong("id"), govId);
+        
+        if (!existingIds.isEmpty()) {
+            String updateSql = "UPDATE users SET provider_user_id = ?, first_name = ?, last_name = ?, updated_at = ? WHERE id = ?";
+            jdbcTemplate.update(updateSql, providerUserId, firstName, lastName, Timestamp.valueOf(LocalDateTime.now()), existingIds.get(0));
+            return existingIds.get(0);
+        } else {
+            String insertSql = "INSERT INTO users (provider_user_id, gov_id, first_name, last_name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)";
+            KeyHolder keyHolder = new GeneratedKeyHolder();
+            
+            jdbcTemplate.update(connection -> {
+                PreparedStatement ps = connection.prepareStatement(insertSql, Statement.RETURN_GENERATED_KEYS);
+                ps.setString(1, providerUserId);
+                ps.setString(2, govId);
+                ps.setString(3, firstName);
+                ps.setString(4, lastName);
+                ps.setTimestamp(5, Timestamp.valueOf(LocalDateTime.now()));
+                ps.setTimestamp(6, Timestamp.valueOf(LocalDateTime.now()));
+                return ps;
+            }, keyHolder);
+            
+            return ((Number) keyHolder.getKeys().get("id")).longValue();
+        }
+    }
+    
+    private List<String> findUserRoles(Long userId) {
+        String sql = "SELECT r.code FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.user_id = ?";
+        return jdbcTemplate.query(sql, (rs, rowNum) -> rs.getString("code"), userId);
+    }
+    
+    @Transactional
+    public void syncUserRoles(Long userId, List<String> roleCodes) {
+        jdbcTemplate.update("DELETE FROM user_roles WHERE user_id = ?", userId);
+        
+        for (String roleCode : roleCodes) {
+            String sql = "INSERT INTO user_roles (user_id, role_id) SELECT ?, id FROM roles WHERE code = ?";
+            jdbcTemplate.update(sql, userId, roleCode);
+        }
+    }
+}

--- a/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/service/LoginCodeService.java
+++ b/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/service/LoginCodeService.java
@@ -1,0 +1,47 @@
+package uk.gov.demo.smcccms.auth.service;
+
+import org.springframework.stereotype.Service;
+import uk.gov.demo.smcccms.auth.repository.LoginCodeRepository;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+public class LoginCodeService {
+    
+    private final LoginCodeRepository loginCodeRepository;
+    private final SecureRandom random;
+    
+    public LoginCodeService(LoginCodeRepository loginCodeRepository) {
+        this.loginCodeRepository = loginCodeRepository;
+        this.random = new SecureRandom();
+    }
+    
+    public String generateCode(Long userId) {
+        String code = generateSixDigitCode();
+        LocalDateTime expiresAt = LocalDateTime.now().plusHours(24);
+        
+        loginCodeRepository.createLoginCode(userId, code, expiresAt);
+        
+        return code;
+    }
+    
+    public Optional<Long> validateAndConsumeCode(String code) {
+        Optional<Long> userId = loginCodeRepository.findUserIdByValidCode(code);
+        
+        if (userId.isPresent()) {
+            loginCodeRepository.consumeCode(code);
+        }
+        
+        return userId;
+    }
+    
+    private String generateSixDigitCode() {
+        return String.format("%06d", random.nextInt(1000000));
+    }
+    
+    public void cleanupExpiredCodes() {
+        loginCodeRepository.cleanupExpiredCodes();
+    }
+}

--- a/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/service/SessionService.java
+++ b/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/service/SessionService.java
@@ -1,0 +1,91 @@
+package uk.gov.demo.smcccms.auth.service;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class SessionService {
+    
+    private static final String COOKIE_NAME = "SMCCCMS_SESSION";
+    private static final String ALGORITHM = "HmacSHA256";
+    
+    private final String sessionSecret;
+    private final Map<String, Long> activeSessions = new ConcurrentHashMap<>();
+    
+    public SessionService(@Value("${session.secret:smcccms-demo-secret-key}") String sessionSecret) {
+        this.sessionSecret = sessionSecret;
+    }
+    
+    public void createSession(Long userId, HttpServletResponse response) {
+        String sessionId = generateSessionId(userId);
+        activeSessions.put(sessionId, userId);
+        
+        Cookie cookie = new Cookie(COOKIE_NAME, sessionId);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false); // Set to true in production with HTTPS
+        cookie.setPath("/api");
+        cookie.setMaxAge(24 * 60 * 60); // 24 hours
+        
+        response.addCookie(cookie);
+    }
+    
+    public boolean isValidSession(String sessionId) {
+        return activeSessions.containsKey(sessionId) && verifySignature(sessionId);
+    }
+    
+    public Long getUserIdFromSession(String sessionId) {
+        return activeSessions.get(sessionId);
+    }
+    
+    public void invalidateSession(String sessionId) {
+        activeSessions.remove(sessionId);
+    }
+    
+    private String generateSessionId(Long userId) {
+        String data = userId.toString() + ":" + System.currentTimeMillis();
+        String signature = sign(data);
+        return Base64.getUrlEncoder().encodeToString((data + ":" + signature).getBytes(StandardCharsets.UTF_8));
+    }
+    
+    private boolean verifySignature(String sessionId) {
+        try {
+            String decoded = new String(Base64.getUrlDecoder().decode(sessionId), StandardCharsets.UTF_8);
+            String[] parts = decoded.split(":");
+            
+            if (parts.length != 3) {
+                return false;
+            }
+            
+            String data = parts[0] + ":" + parts[1];
+            String signature = parts[2];
+            String expectedSignature = sign(data);
+            
+            return signature.equals(expectedSignature);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+    
+    private String sign(String data) {
+        try {
+            Mac mac = Mac.getInstance(ALGORITHM);
+            SecretKeySpec keySpec = new SecretKeySpec(sessionSecret.getBytes(StandardCharsets.UTF_8), ALGORITHM);
+            mac.init(keySpec);
+            byte[] signature = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(signature);
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new RuntimeException("Failed to sign session data", e);
+        }
+    }
+}

--- a/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/service/UserProviderClient.java
+++ b/smcccms_be/src/main/java/uk/gov/demo/smcccms/auth/service/UserProviderClient.java
@@ -1,0 +1,138 @@
+package uk.gov.demo.smcccms.auth.service;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+public class UserProviderClient {
+    
+    private static final Logger logger = LoggerFactory.getLogger(UserProviderClient.class);
+    
+    private final RestTemplate restTemplate;
+    private final String baseUrl;
+    private final String authHeader;
+    
+    public UserProviderClient(RestTemplateBuilder restTemplateBuilder,
+                              @Value("${user.provider.base-url:http://localhost:8081}") String baseUrl,
+                              @Value("${user.provider.username:demo}") String username,
+                              @Value("${user.provider.password:demo}") String password) {
+        this.restTemplate = restTemplateBuilder.build();
+        this.baseUrl = baseUrl;
+        this.authHeader = createBasicAuthHeader(username, password);
+    }
+    
+    private String createBasicAuthHeader(String username, String password) {
+        String credentials = username + ":" + password;
+        byte[] credentialsBytes = credentials.getBytes(StandardCharsets.UTF_8);
+        return "Basic " + Base64.getEncoder().encodeToString(credentialsBytes);
+    }
+    
+    public ProviderUserInfo verifyId(String govId) {
+        String url = baseUrl + "/verify-id";
+        
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("Authorization", authHeader);
+        
+        Map<String, String> request = Map.of("idNumber", govId);
+        HttpEntity<Map<String, String>> entity = new HttpEntity<>(request, headers);
+        
+        try {
+            logger.debug("Calling user provider: POST {} with govId: {}", url, govId);
+            ResponseEntity<ProviderResponse> response = restTemplate.exchange(
+                url, HttpMethod.POST, entity, ProviderResponse.class
+            );
+            
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                ProviderResponse body = response.getBody();
+                return new ProviderUserInfo(
+                    body.providerId,
+                    body.firstName,
+                    body.lastName,
+                    mapProviderRoles(body.roles)
+                );
+            }
+            
+            throw new RuntimeException("Invalid response from user provider");
+            
+        } catch (RestClientException e) {
+            logger.error("Failed to verify ID with provider: {}", e.getMessage());
+            
+            if (govId.matches("^ID-UK-\\d{3}$")) {
+                int userNum = Integer.parseInt(govId.substring(6));
+                String role = determineRole(userNum);
+                return new ProviderUserInfo(
+                    "provider-" + userNum,
+                    "User" + userNum,
+                    "Demo",
+                    List.of(role)
+                );
+            }
+            
+            throw new RuntimeException("User provider unavailable", e);
+        }
+    }
+    
+    private String determineRole(int userNum) {
+        if (userNum % 17 == 0) return "JDG";
+        if (userNum % 11 == 0) return "CWS";
+        if (userNum % 7 == 0) return "SOL";
+        return "RES";
+    }
+    
+    private List<String> mapProviderRoles(List<String> providerRoles) {
+        return providerRoles.stream()
+            .map(role -> {
+                switch (role.toUpperCase()) {
+                    case "RESIDENT": return "RES";
+                    case "SOLICITOR": return "SOL";
+                    case "CASEWORKER": return "CWS";
+                    case "JUDGE": return "JDG";
+                    default: return "RES";
+                }
+            })
+            .distinct()
+            .collect(Collectors.toList());
+    }
+    
+    public static class ProviderUserInfo {
+        public final String providerId;
+        public final String firstName;
+        public final String lastName;
+        public final List<String> roles;
+        
+        public ProviderUserInfo(String providerId, String firstName, String lastName, List<String> roles) {
+            this.providerId = providerId;
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.roles = roles;
+        }
+    }
+    
+    private static class ProviderResponse {
+        @JsonProperty("providerId")
+        public String providerId;
+        
+        @JsonProperty("firstName")
+        public String firstName;
+        
+        @JsonProperty("lastName")
+        public String lastName;
+        
+        @JsonProperty("roles")
+        public List<String> roles;
+    }
+}

--- a/smcccms_be/src/main/resources/application.yml
+++ b/smcccms_be/src/main/resources/application.yml
@@ -59,6 +59,17 @@ management:
     health:
       show-details: when-authorized
 
+# User Provider Configuration
+user:
+  provider:
+    base-url: ${USER_PROVIDER_BASE_URL:http://localhost:8081}
+    username: ${USER_PROVIDER_USERNAME:demo}
+    password: ${USER_PROVIDER_PASSWORD:demo}
+
+# Session Configuration  
+session:
+  secret: ${SESSION_SECRET:smcccms-demo-secret-key-change-in-production}
+
 logging:
   level:
     root: INFO

--- a/smcccms_be/src/test/java/uk/gov/demo/smcccms/auth/service/LoginCodeServiceTest.java
+++ b/smcccms_be/src/test/java/uk/gov/demo/smcccms/auth/service/LoginCodeServiceTest.java
@@ -1,0 +1,82 @@
+package uk.gov.demo.smcccms.auth.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import uk.gov.demo.smcccms.auth.repository.LoginCodeRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class LoginCodeServiceTest {
+    
+    @Mock
+    private LoginCodeRepository loginCodeRepository;
+    
+    private LoginCodeService loginCodeService;
+    
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        loginCodeService = new LoginCodeService(loginCodeRepository);
+    }
+    
+    @Test
+    void generateCode_ShouldCreateSixDigitCode() {
+        Long userId = 1L;
+        when(loginCodeRepository.createLoginCode(eq(userId), anyString(), any(LocalDateTime.class)))
+            .thenReturn(1L);
+        
+        String code = loginCodeService.generateCode(userId);
+        
+        assertNotNull(code);
+        assertEquals(6, code.length());
+        assertTrue(code.matches("\\d{6}"));
+        
+        verify(loginCodeRepository).createLoginCode(eq(userId), eq(code), any(LocalDateTime.class));
+    }
+    
+    @Test
+    void validateAndConsumeCode_ValidCode_ShouldReturnUserId() {
+        String code = "123456";
+        Long expectedUserId = 1L;
+        
+        when(loginCodeRepository.findUserIdByValidCode(code))
+            .thenReturn(Optional.of(expectedUserId));
+        
+        Optional<Long> result = loginCodeService.validateAndConsumeCode(code);
+        
+        assertTrue(result.isPresent());
+        assertEquals(expectedUserId, result.get());
+        
+        verify(loginCodeRepository).findUserIdByValidCode(code);
+        verify(loginCodeRepository).consumeCode(code);
+    }
+    
+    @Test
+    void validateAndConsumeCode_InvalidCode_ShouldReturnEmpty() {
+        String code = "123456";
+        
+        when(loginCodeRepository.findUserIdByValidCode(code))
+            .thenReturn(Optional.empty());
+        
+        Optional<Long> result = loginCodeService.validateAndConsumeCode(code);
+        
+        assertTrue(result.isEmpty());
+        
+        verify(loginCodeRepository).findUserIdByValidCode(code);
+        verify(loginCodeRepository, never()).consumeCode(code);
+    }
+    
+    @Test
+    void cleanupExpiredCodes_ShouldCallRepository() {
+        loginCodeService.cleanupExpiredCodes();
+        
+        verify(loginCodeRepository).cleanupExpiredCodes();
+    }
+}

--- a/smcccms_be/src/test/java/uk/gov/demo/smcccms/auth/service/SessionServiceTest.java
+++ b/smcccms_be/src/test/java/uk/gov/demo/smcccms/auth/service/SessionServiceTest.java
@@ -1,0 +1,68 @@
+package uk.gov.demo.smcccms.auth.service;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class SessionServiceTest {
+    
+    @Mock
+    private HttpServletResponse response;
+    
+    private SessionService sessionService;
+    
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        sessionService = new SessionService("test-secret-key");
+    }
+    
+    @Test
+    void createSession_ShouldSetCookieWithValidSignature() {
+        Long userId = 1L;
+        
+        sessionService.createSession(userId, response);
+        
+        ArgumentCaptor<Cookie> cookieCaptor = ArgumentCaptor.forClass(Cookie.class);
+        verify(response).addCookie(cookieCaptor.capture());
+        
+        Cookie cookie = cookieCaptor.getValue();
+        assertEquals("SMCCCMS_SESSION", cookie.getName());
+        assertEquals("/api", cookie.getPath());
+        assertEquals(24 * 60 * 60, cookie.getMaxAge());
+        
+        // Verify the session ID is valid
+        String sessionId = cookie.getValue();
+        assertTrue(sessionService.isValidSession(sessionId));
+        assertEquals(userId, sessionService.getUserIdFromSession(sessionId));
+    }
+    
+    @Test
+    void isValidSession_InvalidSignature_ShouldReturnFalse() {
+        String invalidSessionId = "invalid-session";
+        
+        assertFalse(sessionService.isValidSession(invalidSessionId));
+    }
+    
+    @Test
+    void invalidateSession_ShouldRemoveSession() {
+        Long userId = 1L;
+        sessionService.createSession(userId, response);
+        
+        ArgumentCaptor<Cookie> cookieCaptor = ArgumentCaptor.forClass(Cookie.class);
+        verify(response).addCookie(cookieCaptor.capture());
+        
+        String sessionId = cookieCaptor.getValue().getValue();
+        assertTrue(sessionService.isValidSession(sessionId));
+        
+        sessionService.invalidateSession(sessionId);
+        assertFalse(sessionService.isValidSession(sessionId));
+    }
+}


### PR DESCRIPTION
## Summary
Implements the complete authentication API for SMCCCMS with three core endpoints:

- **POST /auth/verify-id** - Government ID verification with external provider integration
- **POST /auth/request-code** - 6-digit code generation with 24-hour TTL  
- **POST /auth/verify-code** - Session cookie establishment with HTTP-only security

## Implementation Details

### Backend Architecture
- **DTOs**: Request/response models with validation annotations
- **Repositories**: JDBC-based UserRepository and LoginCodeRepository  
- **Services**: UserProviderClient, LoginCodeService, SessionService
- **Controller**: AuthController with comprehensive OpenAPI documentation

### Key Features
✅ External user provider integration with Basic auth fallback  
✅ Secure 6-digit code generation with database TTL  
✅ Signed session cookies with in-memory session management  
✅ Role-based user assignment (RES/SOL/CWS/JDG)  
✅ Complete error handling with proper HTTP status codes  
✅ Comprehensive Swagger/OpenAPI documentation  

### Testing
- Unit tests for core services (LoginCodeService, SessionService)
- Manual testing via curl and Swagger UI
- All endpoints functional and documented

## API Endpoints

All endpoints are available at `/api/auth/*` and documented in Swagger UI.

### Test Flow
```bash
# 1. Verify government ID
curl -X POST http://localhost:8080/api/auth/verify-id \
  -H "Content-Type: application/json" \
  -d '{"govId": "ID-UK-001"}'

# 2. Request verification code  
curl -X POST http://localhost:8080/api/auth/request-code \
  -H "Content-Type: application/json" \
  -d '{"contact": "test@example.com"}'

# 3. Verify code and create session
curl -X POST http://localhost:8080/api/auth/verify-code \
  -H "Content-Type: application/json" \
  -d '{"code": "123456"}' -c cookies.txt
```

## Documentation Updates
- Enhanced `examples/auth-flow-curl.md` with complete working examples
- Updated `docs/ARCHITECTURE.md` with detailed auth flow documentation
- Added `smcccms_be/README.md` with quick start guide

## Closes Issues
- Closes #11 (BE: POST /auth/verify-id)
- Closes #12 (BE: POST /auth/request-code) 
- Closes #13 (BE: POST /auth/verify-code)

## Next Steps
Ready for PR #3: Frontend screens that consume these auth endpoints.

🤖 Generated with [Claude Code](https://claude.ai/code)